### PR TITLE
Add missing requirement for INT 0x10 AH=0x4F AL=0x15 BH=0x00 (Check VBE/DC Capabilities)

### DIFF
--- a/source/Interrupt List/INT 10 VIDEO CPUgenerated 80286/INT 104F15BL00 VESA VBEDC Display Data Channel INSTALLATION CHECK CAPABILITIES.txt
+++ b/source/Interrupt List/INT 10 VIDEO CPUgenerated 80286/INT 104F15BL00 VESA VBEDC Display Data Channel INSTALLATION CHECK CAPABILITIES.txt
@@ -7,6 +7,8 @@
 INT 10 - VESA VBE/DC (Display Data Channel) - INSTALLATION CHECK / CAPABILITIES
 	AX = 4F15h
 	BL = 00h
+    CX = 00h Controller Unit Number (00 = primary)
+    ES:DI = 0:0
 Return: AL = 4Fh if function supported
 	    AH = status
 		00h successful


### PR DESCRIPTION
I was bit in the backside by this missing documentation, and having it would be very nice. Requirement seen in the Bochs VGABIOS-lgpl-latest. See StackOverflow @ https://stackoverflow.com/a/79918822/32565376.