### PR TITLE
ecm 2026-04k: 2D.mm4x: add hyperlinks to related lDebug ELD functions

### DIFF
--- a/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D40 lDebug AMIS message ELD DISPLAY MESSAGE TO DEBUGGER TERMINAL.txt
+++ b/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D40 lDebug AMIS message ELD DISPLAY MESSAGE TO DEBUGGER TERMINAL.txt
@@ -17,3 +17,4 @@ Return:	AL = 00h if not supported
 Notes:	This function is provided by an ELD (Extension for lDebug)
 	  hooking into the debugger's AMIS handler.
 	Older versions of the ELD only had a buffer of 128 Bytes.
+SeeAlso: INT 2D/AL=41h"lDebug"

--- a/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D41 lDebug AMIS message ELD QUERY MESSAGE STATUS.txt
+++ b/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D41 lDebug AMIS message ELD QUERY MESSAGE STATUS.txt
@@ -13,3 +13,4 @@ Return:	AL = 00h if not supported
 	current amismsg.eld does not destroy any other registers
 Notes:	This function is provided by an ELD (Extension for lDebug)
 	  hooking into the debugger's AMIS handler.
+SeeAlso: INT 2D/AL=40h"lDebug"

--- a/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D44 lDebug RESERVED FOR ELD INTERFACING.txt
+++ b/source/Interrupt List/INT 2D ALTERNATE MULTIPLEX INTERRUPT SPECIFICATION/INT 2D44 lDebug RESERVED FOR ELD INTERFACING.txt
@@ -10,3 +10,5 @@ INT 2D - lDebug - RESERVED FOR ELD INTERFACING
 Return:	AL = 00h if not supported
 Notes:	These functions may be provided by future ELDs (Extensions
 	  for lDebug) hooking into the debugger's AMIS handler.
+SeeAlso: INT 2D/AL=40h"lDebug",INT 2D/AL=41h"lDebug",INT 2D/AL=42h"lDebug"
+SeeAlso: INT 2D/AL=43h"lDebug"


### PR DESCRIPTION
Just a small change today, still working on [intlist.pl](https://github.com/LoopZ/TheList/issues/28)