### PR TITLE
drop AX= references with xxh in favour of AH=

### DIFF
--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2143FFBP5053 MSDOS 720 Win98 EXTENDEDLENGTH FILENAME OPERATIONS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2143FFBP5053 MSDOS 720 Win98 EXTENDEDLENGTH FILENAME OPERATIONS.txt
@@ -19,7 +19,7 @@ Return: CF clear if successful
 	    AX = error code (03h,05h) (see #01680 at AH=59h/BX=0000h)
 Note:	these functions are equivalent to INT 21/AH=39h and INT 21/AH=56h,
 	  but with a maximum path length of 128 characters instead of 67;
-	  unlike INT 21/AX=71xxh, these functions are available under bare
+	  unlike INT 21/AH=71h, these functions are available under bare
 	  DOS and not just in a Windows DOS box
 SeeAlso: AH=39h,AH=56h,AX=7139h,AX=7156h
 

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 214452 DR DOS 341 DETERMINE DOS TYPEGET DR DOS VERSION.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 214452 DR DOS 341 DETERMINE DOS TYPEGET DR DOS VERSION.txt
@@ -174,7 +174,7 @@ Values for Digital Research operating system ID codes (full AX return value):
 	  segment from which the PSP was copied was incorrect so the the PSP
 	  was not filled correctly and did not contain the command tail.
 	- DR DOS 6.0 BDOS patch "PAT314" English (1992-01-10, XDIR /C: C964h)
-	  This patch modifies INT 21/AX=33xxh, the Ctrl Break handler to
+	  This patch modifies INT 21/AH=33h, the Ctrl Break handler to
 	  support undocumented MS-DOS function INT 21/AX=3302h.
 	- DR DOS 6.0 BIOS patch "PAT315" English (1992-01-10, XDIR /C: DBAAh)
 	  This patch fixes a problem where, when booting from a Bernoulli

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2171 Windows95 LONG FILENAME FUNCTIONS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2171 Windows95 LONG FILENAME FUNCTIONS.txt
@@ -50,7 +50,7 @@ Notes:	if error 7100h is returned, the old-style function should be called
 	  (e.g. LONGNAME.TXT -> LONGNAME.TXT, not LONGNA~1.TXT). BETA 3 has
 	  A7h (BL=0, 1) functions added, and 4Eh/4Fh can return file times
 	  in both DOS and 64 bit formats, BETA 4 has support added for
-	  Caldera's DRFAT32 redirector extension (see INT 2F/AX=15xxh).
+	  Caldera's DRFAT32 redirector extension (see INT 2F/AH=15h).
 	Caldera's DR-OpenDOS 7.02+ COMMAND.COM utilizes the LFN API as soon
 	  as it detects it (mind, that LONGNAME.EXE can be dynamically loaded
 	  and unloaded at runtime). This COMMAND.COM shell also works under


### PR DESCRIPTION
The INT 2F/AH=15h is an odd one, as the entries matching this all seem to be about CD redirectors rather than applying to DRFAT32. Someone look into that?