### PR TITLE
ecm 2026-04ac

### DIFF
--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2125 DOS 1 SET INTERRUPT VECTOR.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2125 DOS 1 SET INTERRUPT VECTOR.txt
@@ -20,6 +20,7 @@ Notes:	this function is preferred over direct modification of the interrupt
 	  of just two words in addition to the IRET frame, allowing it to be
 	  called from INT 21h functions, specificially device drivers.  This
 	  fixes the MCS SMB client
+	lDOS as of 2026-04-26 also runs this function on the user stack
 	Novell NetWare (except the new DOS Requester) monitors the offset of
 	  any INT 24 set, and if equal to the value at startup, substitutes
 	  its own handler to allow handling of network errors; this introduces

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2135 DOS 2 GET INTERRUPT VECTOR.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2135 DOS 2 GET INTERRUPT VECTOR.txt
@@ -10,5 +10,6 @@ INT 21 - DOS 2+ - GET INTERRUPT VECTOR
 Return: ES:BX -> current interrupt handler
 Notes:	under DR DOS 5.0+, this function does not use any of the DOS-internal
 	  stacks and may thus be called at any time
+	lDOS as of 2026-04-26 also runs this function on the user stack
 SeeAlso: AH=25h,AX=2503h
 

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 215700 DOS 2 GET FILES LASTWRITTEN DATE AND TIME.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 215700 DOS 2 GET FILES LASTWRITTEN DATE AND TIME.txt
@@ -20,11 +20,18 @@ Bitfields for file time:
 Bit(s)	Description	(Table 01665)
  15-11	hours (0-23)
  10-5	minutes
- 4-0	seconds/2
+ 4-0	seconds/2 (this cannot encode odd seconds)
+Notes:	all of these fields are 0-based
 
 Bitfields for file date:
 Bit(s)	Description	(Table 01666)
- 15-9	year - 1980
+ 15-9	year minus 1980 (0 to 127, corresponding to 1980 to 2107)
  8-5	month
  4-0	day
-
+Notes:	the month and day are encoded 1-based, so that if they hold zeroes
+	  they encode an invalid date. this is typically the case if
+	  the entire file date is all-zeroes.
+	the lDOS bootimg assembler script usually initialises all file dates
+	  and times as all-zeroes. some shells (eg MS-DOS v4.01 command.com)
+	  will detect these and not display any date, others (eg FreeCOM)
+	  may display a stamp like "1980-00-00 00:00:00"

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 215D00 DOS 31 internal SERVER FUNCTION CALL.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 215D00 DOS 31 internal SERVER FUNCTION CALL.txt
@@ -9,7 +9,7 @@ INT 21 U - DOS 3.1+ internal - SERVER FUNCTION CALL
 	DS:DX -> DOS parameter list (see #01686)
 	DPL contains all register values for a call to INT 21h
 Return: as appropriate for function being called
-Notes:	does not check AH.  Out of range values will crash the system
+Notes:	does not check AH. out of range values will crash the system (see BUGS)
 	executes using specified computer ID and process ID
 	sharing delay loops skipped
 	a special sharing mode is enabled to handle FCBs opened across network
@@ -26,6 +26,19 @@ BUGS:	the OS/2 2.0 DOS Boot Session incorrectly maps DOS drive letters,
 	DR DOS 5.0-6.0 merely recursively call INT 21 after loading the
 	  registers from the DPL, leading to problems for peer-to-peer
 	  networks
+	on MS-DOS v4.01 and v5, calling AH=33h,AH=50h,AH=51h,AH=62h, or AH=64h
+	  using this function crashes the system. this is because the DISPATCH
+	  table entries point to the user stack functions, which do not expect
+	  to be called from the main REDISP entry. high function numbers that
+	  exceed the DISPATCH table size (eg AH=6Dh,AH=71h,AH=73h) also crash.
+	lDOS as of 2026-04-26 returns MS-DOS v1 style errors (AL = 00h, CF
+	  unchanged) for the above listed function numbers. AH=25h and AH=35h
+	  are handled in a special way: if they are called directly they use
+	  small handlers on the user stack. if they are called using this
+	  function then the old code that works from REDISP is used instead.
+	Enhanced DR-DOS appears to handle function AH=33h fine(?) but crashes
+	  on AH=75h or higher. it corrupts memory for function AH=62h. likely,
+	  function AH=51h is broken as well. function AH=50h appears fine.
 SeeAlso: AH=3Dh,AH=41h,AH=56h,AH=60h
 
 Format of DOS parameter list:

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 216A DOS 40 COMMIT FILE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 216A DOS 40 COMMIT FILE.txt
@@ -11,7 +11,6 @@ Return: CF clear if successful
 	    AH = 68h
 	CF set on error
 	    AX = error code (06h) (see #01680 at AH=59h/BX=0000h)
-Notes:	identical to AH=68h in DOS 5.0-6.0; not known whether this is the case
-	  in DOS 4.x
+Notes:	identical to AH=68h in MS-DOS v4.01, v5.00, and v6.00
 SeeAlso: AH=68h
 

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 217156 Windows95 LONG FILENAME RENAME FILE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 217156 Windows95 LONG FILENAME RENAME FILE.txt
@@ -13,6 +13,6 @@ Return: CF clear if successful
 	    AX = error code
 		7100h if function not supported
 Notes:	the file may be renamed into a different directory, but not across
-	  disks
+	  drives (just like for AH=56h)
 SeeAlso: AH=56h,AX=7141h,AX=43FFh/BP=5053h
 


### PR DESCRIPTION
Update 21.25, .35 run on user stack as of today's lDOS, 21.5D00 crashes with unsupported function numbers, 21.6A exactly the same as 21.68, change 21.7156 wording to refer to drive, 21.5700 details on time and date formats and all-zeroes date.