### PR TITLE
ecm 2026-05b

### DIFF
--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 213E DOS 2 CLOSE CLOSE FILE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 213E DOS 2 CLOSE CLOSE FILE.txt
@@ -14,7 +14,7 @@ Return: CF clear if successful
 Notes:	if the file was written to, any pending disk writes are performed, the
 	  time and date stamps are set to the current time, and the directory
 	  entry is updated
-	recent versions of DOS preserve AH because some versions of Multiplan
-	  had a bug which depended on AH being preserved
-SeeAlso: AH=10h,AH=3Ch,AH=3Dh,INT 2F/AX=1106h,INT 2F/AX=1227h
-
+	recent versions of DOS (including MS-DOS v4.01) preserve AH in the
+	  AX value returned on success because some versions of Multiplan had
+	  a bug which depended on AH being preserved
+SeeAlso: AH=10h,AH=3Ch,AH=3Dh,INT 2F/AX=1106h,INT 2F/AX=1227h,AH=68h,AH=6Ah

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2140 DOS 2 WRITE WRITE TO FILE OR DEVICE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2140 DOS 2 WRITE WRITE TO FILE OR DEVICE.txt
@@ -44,9 +44,10 @@ BUGS:	a write of zero bytes will appear to succeed when it actually failed
 	  disk free space, then writing using this function. it will allocate
 	  all free clusters to the file but fail to update the file size field.
 	MS-DOS v4 and v5 (at least) will truncate the "amount of clusters to
-	  allocate" to a 16-bit quantity so if trying to allocate eg 256 MiB
-	  on a FAT12 1440 KiB diskette (512 BpC) the needed amount is truncated
-	  and the file is corrupted. this bug does not exist on MS-DOS v7.10,
+	  allocate" to a 16-bit quantity so if trying to allocate eg slightly
+	  more than 256 MiB (1000_1000h Bytes) on a FAT12 1440 KiB diskette
+	  (512 BpC) the needed amount is truncated (eg to 8 clusters) and the
+	  file is corrupted. this bug does not exist on MS-DOS v7.10,
 	  presumably because it calculates the amount as a 32-bit number as it
 	  needs to support large values for FAT32 drives.
 SeeAlso: AH=28h,AH=3Fh"DOS",AH=93h,INT 2F/AX=1109h

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 214407 DOS 2 IOCTL GET OUTPUT STATUS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 214407 DOS 2 IOCTL GET OUTPUT STATUS.txt
@@ -8,7 +8,7 @@ INT 21 - DOS 2+ - IOCTL - GET OUTPUT STATUS
 	AX = 4407h
 	BX = file handle
 Return: CF clear if successful
-	    AL = input status
+	    AL = output status
 		00h not ready
 		FFh ready
 	CF set on error

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 214409 DOS 31 IOCTL CHECK IF BLOCK DEVICE REMOTE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 214409 DOS 31 IOCTL CHECK IF BLOCK DEVICE REMOTE.txt
@@ -31,5 +31,7 @@ Notes:	on local drives, DX bits not listed above are the attribute word from
 	  on the first call; a subsequent call will return the correct error
 	  code
 	this function was not supported by Digital Research's DOS Plus
+BUGS:	MS-DOS v4.00 and v4.01 would dereference the IFS driver pointer in
+	  a redirector CDS (see offset 52h in #01643) to check whether to set
+	  bit 12. this pointer may not be initialised for some redirectors
 SeeAlso: AX=4400h,AX=4408h,AX=440Ah,INT 2F/AX=122Bh
-

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2145 DOS 2 DUP DUPLICATE FILE HANDLE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2145 DOS 2 DUP DUPLICATE FILE HANDLE.txt
@@ -14,6 +14,7 @@ Return: CF clear if successful
 Notes:	moving file pointer for either handle will also move it for the other,
 	  because both will refer to the same system file table
 	for DOS versions prior to 3.3, file writes may be forced to disk by
-	  duplicating the file handle and closing the duplicate
+	  duplicating the file handle and closing the duplicate. the same
+	  effect is available using AH=68h or AH=6Ah on later versions.
 SeeAlso: AH=3Dh,AH=46h
 

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2146 DOS 2 DUP2 FORCEDUP FORCE DUPLICATE FILE HANDLE.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2146 DOS 2 DUP2 FORCEDUP FORCE DUPLICATE FILE HANDLE.txt
@@ -13,7 +13,8 @@ Return: CF clear if successful
 	    AX = error code (04h,06h) (see #01680 at AH=59h/BX=0000h)
 Notes:	closes file with handle CX if it is still open
 	DOS 3.30 hangs if BX=CX on entry
+	lDOS (and predumably MS-DOS v4.01 too) closes the handle and returns
+	  error 06h if BX=CX on entry
 	moving file pointer for either handle will also move it for the other,
 	  because both will refer to the same system file table
 SeeAlso: AH=3Dh,AH=45h
-

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2147 DOS 2 CWD GET CURRENT DIRECTORY.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2147 DOS 2 CWD GET CURRENT DIRECTORY.txt
@@ -13,7 +13,9 @@ Return: CF clear if successful
 	CF set on error
 	    AX = error code (0Fh) (see #01680 at AH=59h/BX=0000h)
 Notes:	the returned path does not include a drive or the initial backslash
-	many Microsoft products for Windows rely on AX being 0100h on success
+	many Microsoft products for Windows rely on AX being 0100h on success,
+	  this does not appear to be true of MS-DOS v4 which only sets AL to
+	  zero explicitly, commented as "MZ 19 Jan 84"
 	under the FlashTek X-32 DOS extender, the buffer pointer is in DS:ESI
 SeeAlso: AH=19h,AH=3Bh,AH=71h,INT 15/AX=DE25h
 

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2150 DOS 2 internal SET CURRENT PROCESS ID SET PSP ADDRESS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2150 DOS 2 internal SET CURRENT PROCESS ID SET PSP ADDRESS.txt
@@ -26,7 +26,7 @@ Notes:	DOS uses the current PSP address to determine which processes own files
 	this function is supported by the OS/2 compatibility box
 	this call was undocumented prior to the release of DOS 5.0
 	FreeDOS Debug/X, lDebug/X, and Enhanced Debug/X may directly write
-	  the PSP field in the SDA (offset 10h in #01687 at AX=5D05h).
+	  the PSP field in the SDA (offset 10h in #01687 at AX=5D06h).
 	  lDebug checks for this field matching its PSP initially and will
 	  disable the direct SDA access on a mismatch. lDebug also uses the
 	  INT 31 segment to track DOSDATA relocations (see INT 2F/AX=1203h).

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2151 DOS 2 internal GET CURRENT PROCESS ID GET PSP ADDRESS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2151 DOS 2 internal GET CURRENT PROCESS ID GET PSP ADDRESS.txt
@@ -18,7 +18,7 @@ Notes:	DOS uses the current PSP address to determine which processes own files
 	identical to the documented AH=62h
 	this call was undocumented prior to the release of DOS 5.0
 	FreeDOS Debug/X, lDebug/X, and Enhanced Debug/X may directly read
-	  the PSP field in the SDA (offset 10h in #01687 at AX=5D05h).
+	  the PSP field in the SDA (offset 10h in #01687 at AX=5D06h).
 	  lDebug checks for this field matching its PSP initially and will
 	  disable the direct SDA access on a mismatch. lDebug also uses the
 	  INT 31 segment to track DOSDATA relocations (see INT 2F/AX=1203h).

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2152 DOS 2 internal SYSVARS GET LIST OF LISTS.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2152 DOS 2 internal SYSVARS GET LIST OF LISTS.txt
@@ -875,6 +875,10 @@ Notes:	the path for invalid drives is normally set to X:\, but may be empty
 	Window NT 4.0 always uses X:\PATH, even for substituted drives (i.e.
 	  the CDS will *not* contain the original path prior to SUBST)
 	SoftWindows on the Macintosh PowerPC sets \\E for the host drive
+BUGS:	MS-DOS v4.00 and v4.01 will dereference the IFS pointer at offset
+	  52h to determine whether a redirector CDS (offset 43h bit 15 set)
+	  is actually remote or not (eg for AX=4409h), but some redirectors
+	  don't initialise the IFS pointer
 SeeAlso: #01644,INT 21/AX=71AAh/BL=00h
 
 Format of DR DOS 5.0-6.0 current directory structure entry (array):

--- a/source/Interrupt List/INT 21 DOS Function Calls/INT 2153 DOS 2 internal TRANSLATE BIOS PARAMETER BLOCK TO DRIVE PARAM BLOCK.txt
+++ b/source/Interrupt List/INT 21 DOS Function Calls/INT 2153 DOS 2 internal TRANSLATE BIOS PARAMETER BLOCK TO DRIVE PARAM BLOCK.txt
@@ -25,6 +25,8 @@ Format of BIOS Parameter Block:
 Offset	Size	Description	(Table 01663)
  00h	WORD	number of bytes per sector
  02h	BYTE	number of sectors per cluster
+		for the Enhanced DR-DOS extension of 256 sectors per cluster,
+		  this byte contains 00h (presumed to cause a hang on MS-DOS)
  03h	WORD	number of reserved sectors at start of disk
  05h	BYTE	number of FATs
  06h	WORD	number of entries in root directory
@@ -66,7 +68,8 @@ Offset	Size	Description	(Table 01664)
 		bits 3-0: the 0-based FAT number of the active FAT
 		    (if mirroring disabled)
  1Fh	WORD	file system version (high byte=major, low byte=minor)
-		0000h = Win95-OSR2
+		0000h = MSWindows95-OSR2
+		0001h = Enhanced DR-DOS FAT32 with explicit FAT+ support
  21h	DWORD	starting cluster number of root directory
  25h	WORD	file system information sector number (see also #01788)
 		FFFFh if none


### PR DESCRIPTION
Update exact numbers for 21.40 bug, fix debugger references to 21.5D06, mention EDR-DOS extensions to 21.53, 21.3E returns AH=3Eh on MS-DOS v4, 21.4407 fix AL name, 21.4409 list MS-DOS v4/redirector bug, 21.45 reference newer commit syscalls, 21.46 closes handle if BX=CX, 21.47 doesn't set AX = 0100h for MS-DOS v4